### PR TITLE
`rust-ffmpeg-splitter`: Fix AV1 encoder flag

### DIFF
--- a/compile-ffmpeg.mjs
+++ b/compile-ffmpeg.mjs
@@ -119,7 +119,6 @@ if (!existsSync(PREFIX)) {
   fs.mkdirSync(PREFIX);
 }
 
-execSync("git config --global advice.detachedHead false");
 const isWindows = process.argv.includes("windows");
 const isMusl = process.argv.includes("musl");
 const isOldCmake = process.argv.includes("old-cmake");
@@ -268,7 +267,7 @@ execSync(
     "--enable-encoder=pcm_s24le",
     "--enable-encoder=libx264",
     "--enable-encoder=libx265",
-    "--enable-encoder=libaom-av1",
+    "--enable-encoder=libaom_av1",
     "--enable-libvpx",
     "--enable-encoder=libvpx_vp8",
     "--enable-encoder=libvpx_vp9",

--- a/test-ffmpeg.mjs
+++ b/test-ffmpeg.mjs
@@ -31,6 +31,16 @@ if (exit1.status !== 0) {
 }
 assert(exit1.status === 0);
 
+const encoders = spawnSync(ffmpegBinary, ["-hide_banner", "-encoders"], {
+  env,
+});
+if (encoders.status !== 0) {
+  console.log(encoders.stderr.toString("utf8"));
+  console.log(encoders.stdout.toString("utf8"));
+}
+assert(encoders.status === 0);
+assert(encoders.stdout.toString("utf8").includes("libaom-av1"));
+
 const exit2 = spawnSync(
   ffmpegBinary,
   ["-i", "sample-5s.webm", "-t", "1", "out-test.mp4", "-y"],
@@ -143,4 +153,24 @@ const exit6 = spawnSync(
   }
 );
 assert(exit6.status === 0);
+
+const exit7 = spawnSync(
+  ffmpegBinary,
+  [
+    "-i",
+    "sample.mp4",
+    "-frames:v",
+    "1",
+    "-an",
+    "-c:v",
+    "libaom-av1",
+    "out-test-libaom-av1.mkv",
+    "-y",
+  ],
+  {
+    env,
+    stdio: "inherit",
+  }
+);
+assert(exit7.status === 0);
 console.log("Hooray!");


### PR DESCRIPTION
## Summary
- Fix the FFmpeg configure flag for the libaom AV1 encoder by using the `libaom_av1` component selector instead of the runtime encoder name.
- Add a smoke test that verifies `libaom-av1` appears in `ffmpeg -encoders` and that a minimal AV1 encode succeeds.
- Remove the build script's global git config write so running the build does not modify the developer machine.

## Test plan
- [x] Rebuild the splitter output locally on macOS arm64.
- [x] Verify `remotion/bin/ffmpeg -encoders` lists `libaom-av1`.
- [x] Run `node test-ffmpeg.mjs` and confirm the AV1 encode smoke test passes.

Made with [Cursor](https://cursor.com)