### PR TITLE
`rust-ffmpeg-splitter`: Disable AV1 encoder for Lambda target

### DIFF
--- a/Dockerfile-aws
+++ b/Dockerfile-aws
@@ -26,5 +26,5 @@ RUN yum install yasm nasm unzip curl gcc gcc-c++ tar git make ca-certificates pk
 RUN cd app && CFLAGS="$CFLAGS -static-libgcc" CXXFLAGS="$CXXFLAGS -static-libgcc -static-libstdc++" LDFLAGS="$LDFLAGS -static-libgcc -static-libstdc++" node compile-ffmpeg.mjs old-cmake
 RUN source "$HOME/.cargo/env" && cd app && node generate-bindings.mjs
 RUN source "$HOME/.cargo/env" && cd app && node zip.mjs
-RUN source "$HOME/.cargo/env" && cd app && node test-ffmpeg.mjs
+RUN source "$HOME/.cargo/env" && cd app && EXPECT_AV1_ENCODER=0 node test-ffmpeg.mjs
 

--- a/compile-av1.mjs
+++ b/compile-av1.mjs
@@ -179,7 +179,12 @@ const enableLibaom = (isWindows) => {
   });
 };
 
-export const enableAv1 = (isWindows) => {
+export const enableAv1 = ({
+  isWindows,
+  enableEncoder,
+}) => {
   enableDav1d(isWindows);
-  enableLibaom(isWindows);
+  if (enableEncoder) {
+    enableLibaom(isWindows);
+  }
 };

--- a/compile-ffmpeg.mjs
+++ b/compile-ffmpeg.mjs
@@ -122,9 +122,15 @@ if (!existsSync(PREFIX)) {
 const isWindows = process.argv.includes("windows");
 const isMusl = process.argv.includes("musl");
 const isOldCmake = process.argv.includes("old-cmake");
+const isLambdaTarget =
+  process.platform === "linux" &&
+  process.arch === "arm64" &&
+  !isMusl &&
+  !isWindows;
+const shouldEnableAv1Encoder = !isLambdaTarget;
 
 await enableFdkAac(isWindows);
-enableAv1(isWindows);
+enableAv1({ isWindows, enableEncoder: shouldEnableAv1Encoder });
 enableZimg(isWindows);
 enableVpx(isWindows);
 enableX264(isMusl, isWindows);
@@ -216,7 +222,7 @@ execSync(
     "--enable-small",
     "--enable-shared",
     "--enable-libdav1d",
-    "--enable-libaom",
+    shouldEnableAv1Encoder ? "--enable-libaom" : null,
     "--enable-libzimg",
     "--enable-libfdk-aac",
     "--disable-static",
@@ -267,7 +273,7 @@ execSync(
     "--enable-encoder=pcm_s24le",
     "--enable-encoder=libx264",
     "--enable-encoder=libx265",
-    "--enable-encoder=libaom_av1",
+    shouldEnableAv1Encoder ? "--enable-encoder=libaom_av1" : null,
     "--enable-libvpx",
     "--enable-encoder=libvpx_vp8",
     "--enable-encoder=libvpx_vp9",

--- a/test-ffmpeg.mjs
+++ b/test-ffmpeg.mjs
@@ -21,6 +21,7 @@ const env =
       };
 
 const ffmpegBinary = path.join(process.cwd(), "remotion", "bin", "ffmpeg");
+const shouldHaveAv1Encoder = process.env.EXPECT_AV1_ENCODER !== "0";
 
 const exit1 = spawnSync(ffmpegBinary, ["-buildconf"], {
   env,
@@ -39,7 +40,9 @@ if (encoders.status !== 0) {
   console.log(encoders.stdout.toString("utf8"));
 }
 assert(encoders.status === 0);
-assert(encoders.stdout.toString("utf8").includes("libaom-av1"));
+assert(
+  encoders.stdout.toString("utf8").includes("libaom-av1") === shouldHaveAv1Encoder
+);
 
 const exit2 = spawnSync(
   ffmpegBinary,
@@ -154,23 +157,25 @@ const exit6 = spawnSync(
 );
 assert(exit6.status === 0);
 
-const exit7 = spawnSync(
-  ffmpegBinary,
-  [
-    "-i",
-    "sample.mp4",
-    "-frames:v",
-    "1",
-    "-an",
-    "-c:v",
-    "libaom-av1",
-    "out-test-libaom-av1.mkv",
-    "-y",
-  ],
-  {
-    env,
-    stdio: "inherit",
-  }
-);
-assert(exit7.status === 0);
+if (shouldHaveAv1Encoder) {
+  const exit7 = spawnSync(
+    ffmpegBinary,
+    [
+      "-i",
+      "sample.mp4",
+      "-frames:v",
+      "1",
+      "-an",
+      "-c:v",
+      "libaom-av1",
+      "out-test-libaom-av1.mkv",
+      "-y",
+    ],
+    {
+      env,
+      stdio: "inherit",
+    }
+  );
+  assert(exit7.status === 0);
+}
 console.log("Hooray!");


### PR DESCRIPTION
## Summary
- Disable the libaom AV1 encoder only for the Linux arm64 GNU build used by Remotion Lambda.
- Keep AV1 decode support and keep AV1 encoding enabled on the other desktop and server targets.
- Update the Docker-based Lambda smoke test to expect the AV1 encoder to be unavailable while preserving the regular AV1 assertion on the other platforms.

## Test plan
- [x] Run `node test-ffmpeg.mjs` locally on macOS and confirm the non-Lambda AV1 encoder path still passes.
- [x] Let CI verify the Linux arm64 GNU Docker build skips the AV1 encoder while the other targets keep it.

Made with [Cursor](https://cursor.com)