### PR TITLE
Add NVENC (h264_nvenc, hevc_nvenc) encoder support for Linux builds

### DIFF
--- a/compile-ffmpeg.mjs
+++ b/compile-ffmpeg.mjs
@@ -12,6 +12,7 @@ import { enableAv1 } from "./compile-av1.mjs";
 import { enableFdkAac } from "./compile-fdkaac.mjs";
 import { enableZimg } from "./compile-zimg.mjs";
 import { fixLinuxLinks } from "./fix-linux-links.mjs";
+import { enableNvencHeaders } from "./compile-nvenc.mjs";
 
 if (existsSync("/opt/homebrew/opt/libx11/lib/libX11.6.dylib")) {
   console.log(
@@ -137,6 +138,7 @@ enableX264(isMusl, isWindows);
 enableX265(isMusl, isWindows, isOldCmake);
 enableLibMp3Lame(isWindows);
 enableOpus(isWindows);
+enableNvencHeaders(isWindows);
 
 const TAG = "n7.1";
 
@@ -287,6 +289,12 @@ execSync(
     process.platform === "darwin" ? "--enable-encoder=hevc_videotoolbox" : null,
     process.platform === "darwin"
       ? "--enable-encoder=prores_videotoolbox"
+      : null,
+    !isWindows && process.platform === "linux"
+      ? "--enable-encoder=h264_nvenc"
+      : null,
+    !isWindows && process.platform === "linux"
+      ? "--enable-encoder=hevc_nvenc"
       : null,
     "--disable-muxers",
     "--enable-muxer=webm,opus,mp4,wav,mp3,mov,matroska,hevc,h264,gif,image2,image2pipe,adts,m4a,mpegts,null,avi",

--- a/compile-nvenc.mjs
+++ b/compile-nvenc.mjs
@@ -1,0 +1,33 @@
+import { execSync } from "child_process";
+import { existsSync } from "fs";
+import { PREFIX } from "./const.mjs";
+
+const NV_CODEC_HEADERS_TAG = "n12.2.16.0";
+
+export const enableNvencHeaders = (isWindows) => {
+	// Only install on native Linux builds (not macOS, not Windows cross-compile)
+	// nv-codec-headers are header-only - no runtime dependency at build time
+	if (process.platform !== "linux" || isWindows) return;
+
+	if (!existsSync("nv-codec-headers")) {
+		execSync(
+			"git clone https://github.com/FFmpeg/nv-codec-headers.git",
+			{stdio: "inherit"},
+		);
+	}
+
+	execSync("git fetch --all --tags", {
+		cwd: "nv-codec-headers",
+		stdio: "inherit",
+	});
+
+	execSync(`git checkout ${NV_CODEC_HEADERS_TAG}`, {
+		cwd: "nv-codec-headers",
+		stdio: "inherit",
+	});
+
+	execSync(`make install PREFIX=${PREFIX}`, {
+		cwd: "nv-codec-headers",
+		stdio: "inherit",
+	});
+};

--- a/compile-nvenc.mjs
+++ b/compile-nvenc.mjs
@@ -2,7 +2,7 @@ import { execSync } from "child_process";
 import { existsSync } from "fs";
 import { PREFIX } from "./const.mjs";
 
-const NV_CODEC_HEADERS_TAG = "n12.2.16.0";
+const NV_CODEC_HEADERS_TAG = "n12.2.72.0";
 
 export const enableNvencHeaders = (isWindows) => {
 	// Only install on native Linux builds (not macOS, not Windows cross-compile)


### PR DESCRIPTION
## Summary

Add NVIDIA NVENC hardware encoder support (`h264_nvenc`, `hevc_nvenc`) to the FFmpeg build for Linux targets.

### Changes

**New file: `compile-nvenc.mjs`**
- Clones `FFmpeg/nv-codec-headers` (tag `n12.2.16.0`) and installs to PREFIX
- Header-only — no library compilation, no runtime dependency at build time
- Only runs on native Linux builds (`process.platform === "linux" && !isWindows`)

**Modified: `compile-ffmpeg.mjs`**
- Import and call `enableNvencHeaders(isWindows)` alongside other `enable*` functions
- Add `--enable-encoder=h264_nvenc` and `--enable-encoder=hevc_nvenc` to FFmpeg configure
- Guarded by `!isWindows && process.platform === "linux"` — mirrors the existing VideoToolbox pattern for macOS

### Platform impact

| Platform | NVENC | Notes |
|---|---|---|
| Linux x86_64 glibc | ✅ Enabled | Desktop/server with NVIDIA GPUs |
| Linux x86_64 musl | ✅ Enabled | No GPU typically, but harmless |
| Linux x86_64 musl | ✅ Enabled | No GPU typically, but harmless |
| Linux ARM64 gnu (Lambda) | ✅ Enabled | No GPU, harmless |
| Linux ARM64 musl | ✅ Enabled | No GPU, harmless |
| Windows x86_64 | ❌ Skipped | Cross-compile complexity |
| macOS | ❌ Skipped | Uses VideoToolbox instead |

### How it works

1. `enableNvencHeaders()` clones `nv-codec-headers` and installs to `PREFIX/include/ffnvcodec/` + `PREFIX/lib/pkgconfig/ffnvcodec.pc`
2. FFmpeg's configure auto-detects NVENC via pkg-config (`ffnvcodec` package)
3. Since the build uses `--disable-encoders` + selective re-enable, we explicitly add `--enable-encoder=h264_nvenc` and `--enable-encoder=hevc_nvenc`
4. At runtime, NVENC encoders are available if NVIDIA GPU + driver are present; they fail gracefully otherwise

### Testing

- CI will build all 7 platform targets — success confirms FFmpeg compiles with NVENC headers
- Runtime NVENC encoding cannot be tested in CI (no GPU on runners)
- Corresponding Remotion PR: remotion-dev/remotion#7733