### PR TITLE
Add Windows NVENC build support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ jobs:
           keys:
             - ffmpeg_source-windows
       - run: sudo apt-get update
-      - run: sudo apt-get install -y yasm nasm mingw-w64 mingw-w64-tools libz-mingw-w64-dev clang build-essential zlib1g zlib1g-dev meson ninja-build autoconf automake libtool
+      - run: sudo apt-get install -y yasm nasm pkg-config mingw-w64 mingw-w64-tools libz-mingw-w64-dev clang build-essential zlib1g zlib1g-dev meson ninja-build autoconf automake libtool
       - run: curl https://sh.rustup.rs -sSf | sh -s -- -y
       - run: source "$HOME/.cargo/env" && rustup target add x86_64-pc-windows-gnu
       - run: node clean.mjs

--- a/compile-ffmpeg.mjs
+++ b/compile-ffmpeg.mjs
@@ -267,6 +267,8 @@ execSync(
     "--disable-debug",
     "--enable-gpl",
     "--enable-nonfree",
+    shouldEnableNvenc ? "--enable-ffnvcodec" : null,
+    shouldEnableNvenc ? "--enable-nvenc" : null,
     "--disable-encoders",
     "--enable-encoder=opus",
     "--enable-encoder=aac",
@@ -319,6 +321,23 @@ execSync(
     stdio: "inherit",
   }
 );
+
+if (shouldEnableNvenc) {
+  const configMak = fs.readFileSync(
+    path.join("ffmpeg", "ffbuild", "config.mak"),
+    "utf8"
+  );
+  for (const config of [
+    "CONFIG_FFNVCODEC",
+    "CONFIG_NVENC",
+    "CONFIG_H264_NVENC_ENCODER",
+    "CONFIG_HEVC_NVENC_ENCODER",
+  ]) {
+    if (!configMak.includes(`${config}=yes`)) {
+      throw new Error(`Expected FFmpeg configure to enable ${config}`);
+    }
+  }
+}
 
 execSync("make clean", {
   cwd: "ffmpeg",


### PR DESCRIPTION
## Summary
- install `pkg-config` in the Windows cross-build so FFmpeg can discover `nv-codec-headers`
- explicitly enable FFmpeg `ffnvcodec`/`nvenc` components when NVENC is expected
- fail the build if `h264_nvenc` or `hevc_nvenc` is not present in FFmpeg's generated config

## Validation
- `node --check compile-ffmpeg.mjs`
- `node --check compile-nvenc.mjs`
- `git diff --check`